### PR TITLE
Add secure pin generation for ui

### DIFF
--- a/cmd/bodies_download.go
+++ b/cmd/bodies_download.go
@@ -16,17 +16,17 @@ import (
 const VisLimit = 1000
 
 type BodyDownload struct {
-	Legends [9]bool
-	BlockNum uint64
-	Pre1 []struct{}
-	Pre10 []struct{}
-	Pre100 []struct{}
-	Pre1_000 []struct{}
-	Pre10_000 []struct{}
-	Pre100_000 []struct{}
-	Pre1_000_000 []struct{}
+	Legends       [9]bool
+	BlockNum      uint64
+	Pre1          []struct{}
+	Pre10         []struct{}
+	Pre100        []struct{}
+	Pre1_000      []struct{}
+	Pre10_000     []struct{}
+	Pre100_000    []struct{}
+	Pre1_000_000  []struct{}
 	Pre10_000_000 []struct{}
-	States []SnapshotItem
+	States        []SnapshotItem
 }
 
 type SnapshotItem struct {
@@ -100,14 +100,14 @@ func (uih *UiHandler) bodiesDownload(ctx context.Context, w http.ResponseWriter,
 				}
 				if changesMode {
 					/*
-					if _, ok := changes[id]; ok {
-						if firstItem, firstOk := snapshot.Min(); firstOk {
-							if id < firstItem.Id + VisLimit {
-								sendSnapshot(snapshot, w, templ, sendEvery)
-								maps.Clear(changes)
+						if _, ok := changes[id]; ok {
+							if firstItem, firstOk := snapshot.Min(); firstOk {
+								if id < firstItem.Id + VisLimit {
+									sendSnapshot(snapshot, w, templ, sendEvery)
+									maps.Clear(changes)
+								}
 							}
 						}
-					}
 					*/
 					tick++
 				}
@@ -121,7 +121,7 @@ func (uih *UiHandler) bodiesDownload(ctx context.Context, w http.ResponseWriter,
 		}
 		sendSnapshot(snapshot, w, templ, sendEvery)
 		maps.Clear(changes)
-		<- sendEvery.C
+		<-sendEvery.C
 	}
 }
 
@@ -134,25 +134,25 @@ func sendSnapshot(snapshot *btree.BTreeG[SnapshotItem], w http.ResponseWriter, t
 			first = false
 			bd.BlockNum = item.Id
 			pre := int(bd.BlockNum)
-			bd.Pre10_000_000 = make([]struct{}, pre / 10_000_000)
+			bd.Pre10_000_000 = make([]struct{}, pre/10_000_000)
 			pre %= 10_000_000
-			bd.Pre1_000_000 = make([]struct{}, pre / 1_000_000)
+			bd.Pre1_000_000 = make([]struct{}, pre/1_000_000)
 			pre %= 1_000_000
-			bd.Pre100_000 = make([]struct{}, pre / 100_000)
+			bd.Pre100_000 = make([]struct{}, pre/100_000)
 			pre %= 100_000
-			bd.Pre10_000 = make([]struct{}, pre / 10_000)
+			bd.Pre10_000 = make([]struct{}, pre/10_000)
 			pre %= 10_000
-			bd.Pre1_000 = make([]struct{}, pre / 1_000)
+			bd.Pre1_000 = make([]struct{}, pre/1_000)
 			pre %= 1_000
-			bd.Pre100 = make([]struct{}, pre / 100)
+			bd.Pre100 = make([]struct{}, pre/100)
 			pre %= 100
-			bd.Pre10 = make([]struct{}, pre / 10)
+			bd.Pre10 = make([]struct{}, pre/10)
 			pre %= 10
 			bd.Pre1 = make([]struct{}, pre)
 		}
 		bd.States = append(bd.States, item)
 		bd.Legends[item.State] = true
-		return item.Id < bd.BlockNum + VisLimit // We limit visualisation to VisLimit first blocks
+		return item.Id < bd.BlockNum+VisLimit // We limit visualisation to VisLimit first blocks
 	})
 	if err := templ.ExecuteTemplate(w, "body_download.html", bd); err != nil {
 		fmt.Fprintf(w, "Executing body_download template: %v", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,7 @@ var (
 	serverKeyFile  string
 	serverCertFile string
 	caCertFiles    []string
+	insecure	   bool
 
 	rootCmd = &cobra.Command{
 		Use:   "diagnostics",
@@ -55,6 +56,7 @@ func init() {
 	rootCmd.Flags().StringVar(&serverCertFile, "tls.cert", "", "paths to server TLS certificates")
 	rootCmd.MarkFlagRequired("tls.cert")
 	rootCmd.Flags().StringSliceVar(&caCertFiles, "tls.cacerts", []string{}, "comma-separated list of paths to and CAs TLS certificates")
+	rootCmd.Flags().BoolVar(&insecure, "insecure", false, "whether to use insecure PIN generation for testing purposes (default is false)")
 }
 
 func initConfig() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,7 +28,7 @@ var (
 	serverKeyFile  string
 	serverCertFile string
 	caCertFiles    []string
-	insecure	   bool
+	insecure       bool
 
 	rootCmd = &cobra.Command{
 		Use:   "diagnostics",

--- a/cmd/ui_handler.go
+++ b/cmd/ui_handler.go
@@ -213,14 +213,14 @@ func (uih *UiHandler) allocateNewNodeSession() (uint64, *NodeSession, error) {
 	uih.nodeSessionsLock.Lock()
 	defer uih.nodeSessionsLock.Unlock()
 	pin, err := generatePIN()
-	if err != nil{
+	if err != nil {
 		return pin, nil, err
 	}
-	
+
 	for _, ok := uih.nodeSessions[pin]; ok; _, ok = uih.nodeSessions[pin] {
 		pin, err = generatePIN()
 	}
-	if err != nil{
+	if err != nil {
 		return pin, nil, err
 	}
 	nodeSession := &NodeSession{requestCh: make(chan *NodeRequest, 16)}


### PR DESCRIPTION
Adds secure random number for PIN
Using the ``crypto/rand`` go package for secure random number generation for UI PIN.
Ref: [rand package](https://pkg.go.dev/crypto/rand#section-documentation)

Also adds a flag ``--insecure`` flag to the diagnostics cmd line. When this flag is specified, the insecure random number generation using ``math/rand`` package is used. Defaults to ``false`` i.e. SRNG.