### PR TITLE
Add log rotation system with lumberjack

### DIFF
--- a/cmd/diagnostics/config.go
+++ b/cmd/diagnostics/config.go
@@ -19,6 +19,12 @@ var (
 	insecure        bool
 	maxNodeSessions int
 	maxUISessions   int
+	logDirPath      string //path of directory to save log file
+	logFileName     string //name of log file with format
+	logFileSizeMax  int    //maximum file size for 1 log file
+	logFilesMax     int    //maximum number of backup log files the specified directory can have
+	logFilesAgeMax  int    //maximum number of days a log file will persist in file
+	logCompress     bool   //whether to compress old log files
 
 	rootCmd = &cobra.Command{
 		Use:   "diagnostics",
@@ -44,6 +50,12 @@ func init() {
 	rootCmd.Flags().BoolVar(&insecure, "insecure", false, "whether to use insecure PIN generation for testing purposes (default is false)")
 	rootCmd.Flags().IntVar(&maxNodeSessions, "node.sessions", 5000, "maximum number of node sessions to allow")
 	rootCmd.Flags().IntVar(&maxUISessions, "ui.sessions", 5000, "maximum number of UI sessions to allow")
+	rootCmd.Flags().StringVar(&logDirPath, "log.dir.path", "./logs", "directory path to store logs data")
+	rootCmd.Flags().StringVar(&logFileName, "log.file.name", "diagnostics.log", "directory path to store logs data")
+	rootCmd.Flags().IntVar(&logFileSizeMax, "log.file.size.max", 100, "maximum size of log file in mega bytes to allow")
+	rootCmd.Flags().IntVar(&logFilesAgeMax, "log.file.age.max", 28, "maximum age in days a log file can persist in system")
+	rootCmd.Flags().IntVar(&logFilesMax, "log.max.backup", 5, "maximum number of log files that can persist")
+	rootCmd.Flags().BoolVar(&logCompress, "log.compress", false, "whether to compress historical log files or not")
 }
 
 func initConfig() {

--- a/cmd/diagnostics/main.go
+++ b/cmd/diagnostics/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ledgerwatch/diagnostics/api"
 	"github.com/ledgerwatch/diagnostics/assets"
 	"github.com/ledgerwatch/diagnostics/internal/erigon_node"
+	"github.com/ledgerwatch/diagnostics/internal/logging"
 	"github.com/ledgerwatch/diagnostics/internal/sessions"
 )
 
@@ -25,6 +26,9 @@ func main() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+
+	//set up logger to implement log rotation
+	logging.SetupLogger(logDirPath, logFileName, logFileSizeMax, logFilesAgeMax, logFilesMax, logCompress)
 
 	// Use of system calls SIGINT and SIGTERM signals that cause a gracefully  stop.
 	signalCh := make(chan os.Signal, 1)

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/exp v0.0.0-20230420155640-133eef4313cb
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -478,6 +478,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,18 @@
+package logging
+
+import (
+	"log"
+
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+// update defaut log package's io writer to lumberjack's io writer
+func SetupLogger(logDirPath string, logFileName string, logFileSizeMax int, logFilesAgeMax int, logFilesMax int, logCompress bool) {
+	log.SetOutput(&lumberjack.Logger{
+		Filename:   logDirPath + "/" + logFileName, //name of log file
+		MaxSize:    logFileSizeMax,                 //maximum size of 1 log file
+		MaxBackups: logFilesMax,                    //maximum nuber of log file the specified directory can have
+		MaxAge:     logFilesAgeMax,                 //maximum age in days that a file can persist
+		Compress:   logCompress,                    //should historical log files be compressed
+	})
+}


### PR DESCRIPTION
## Overview
This PR introduces logging enhancements for better logging management. `lumberjack` library is integrated for log rotation. This ensures that the application's logs are rotated periodically, preventing excessive disk space usage, and facilitating easier log analysis.

Additionally, the PR introduces several new command-line flags that allow for fine-grained control over the logging behavior of the application.

### The new flags include:

- **log.dir.path**: Directory path to store logs data.
- **log.file.name**: Name of the log file.
- **log.file.size.max**: Maximum size of a log file in megabytes.
- **log.file.age.max**: Maximum age in days a log file can persist in system.
- **log.max.backup**: Maximum number of log files that can persist.
- **log.compress**: Whether to compress old log files or not.
 
These flags allow users to control where logs are stored, the maximum size of individual log files, how long log files are retained, how many backup log files are kept, and whether or not to compress old log files.

### An example command might look like:
```
./_bin/diagnostics --tls.cert _demo-tls/diagnostics.crt --tls.key _demo-tls/diagnostics-key.pem --tls.cacerts _demo-tls/CA-cert.pem --log.dir.path /home/user/light-node --log.file.name ddgn.log
```

## Future work

Going forward, we may consider integrating an additional logging library such as `logrus` to provide more granular control over log levels or verbosity.
Additionally, `logrus` supports structured logging, which means that logs can be outputted in a machine-readable format (like JSON). This is particularly useful when the logs are to be processed by other software for log analysis and visualization.
We could potentially incorporate these flags (`LogConsoleJsonFlag`, `LogDirJsonFlag`, `LogVerbosityFlag`, `LogConsoleVerbosityFlag`, `LogDirPathFlag`, `LogDirVerbosityFlag`) with `logrus`, further enhancing the flexibility and control we have over our logging strategy.